### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ if (__DEV__) {
   const connectDatabases = require('react-native-flipper-databases').default;
 
   // Import required DBDrivers
-  const WatermelonDBDriver = require('react-native-flipper-databases/drivers/watermelondb').default;
+  const WatermelonDBDriver = require('react-native-flipper-databases/src/drivers/watermelondb').default;
 
   connectDatabases([
     new WatermelonDBDriver(database), // Pass in database definition


### PR DESCRIPTION
## Description

After installing, I noticed `DBDrivers` was pointing to the wrong path in thedocumentation. There's a `src` folder between `react-native-flippper-databases` and `drivers`

## Type of change

- Documentation change

## How Has This Been Tested?

Not applicable

## Checklist:

Not applicable
